### PR TITLE
Various changes

### DIFF
--- a/alien_wallpaper/__init__.py
+++ b/alien_wallpaper/__init__.py
@@ -1,6 +1,6 @@
 """Public exports of alien_wallpaper."""
 
-from . import daemon
+from . import console, daemon
 from .image_downloader import CustomFeed, ImageDownloader
 
 __version__ = "1.0.0"

--- a/alien_wallpaper/console.py
+++ b/alien_wallpaper/console.py
@@ -9,6 +9,8 @@ from typing import List
 from . import daemon
 from .image_downloader import CustomFeed, ImageDownloader
 
+LOG_FORMAT = "%(levelname)s|%(asctime)s|%(message)s"
+
 DEFAULT_SUBREDDITS = [
     "ArchitecturePorn",
     "CityPorn",
@@ -18,7 +20,7 @@ DEFAULT_SUBREDDITS = [
     "winterporn",
     "quoteporn",
 ]
-IMAGE_DOWNLOAD_LIMIT = 25
+IMAGE_DOWNLOAD_LIMIT = 1
 
 
 def run_download_images_command(args: argparse.Namespace):
@@ -97,7 +99,7 @@ def parse_cli_args(args: List[str]):
 def main():
     args = parse_cli_args(sys.argv[1:])
     logging_level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(stream=sys.stdout, level=logging_level)
+    logging.basicConfig(format=LOG_FORMAT, stream=sys.stdout, level=logging_level)
 
     # Run subcommand
     args.func(args)

--- a/alien_wallpaper/console.py
+++ b/alien_wallpaper/console.py
@@ -85,7 +85,7 @@ def parse_cli_args(args: List[str]):
     parser = argparse.ArgumentParser(
         prog="alien_wallpaper", description="Download images from Reddit."
     )
-    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
 
     subparsers = parser.add_subparsers(dest="cmd", required=True)
     add_download_arg_parser(subparsers)

--- a/alien_wallpaper/console.py
+++ b/alien_wallpaper/console.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import List
 
 from . import daemon
 from .image_downloader import CustomFeed, ImageDownloader
@@ -79,22 +80,22 @@ def add_daemon_arg_parser(subparsers):
     status_parser.set_defaults(func=daemon.run_daemon_status_command)
 
 
-def parse_cli_args():
+def parse_cli_args(args: List[str]):
     """Parses command line arguments."""
     parser = argparse.ArgumentParser(
         prog="alien_wallpaper", description="Download images from Reddit."
     )
     parser.add_argument("--verbose", action="store_true")
 
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
     add_download_arg_parser(subparsers)
     add_daemon_arg_parser(subparsers)
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main():
-    args = parse_cli_args()
+    args = parse_cli_args(sys.argv[1:])
     logging_level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(stream=sys.stdout, level=logging_level)
 

--- a/alien_wallpaper/image_downloader.py
+++ b/alien_wallpaper/image_downloader.py
@@ -117,7 +117,7 @@ class ImageDownloader:
             ) as out_file:
                 shutil.copyfileobj(response, out_file)
         except urllib.error.HTTPError as ex:
-            logger.exception(ex)
+            logger.exception("Failed to download %s due to %s", post.id, ex.strerror)
             raise
 
     def _download_images_from_feed(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -12,3 +12,10 @@ def test_parse_cli_args_when_called_with_no_args_fails(capsys):
         console.parse_cli_args(raw_args)
     output = capsys.readouterr().err
     assert "the following arguments are required: cmd" in output
+
+
+def test_parse_cli_args_when_called_with_short_v_returns_verbose():
+    """Verifies parse_cli_args when called with -v is the same as --verbose."""
+    raw_args = ["-v", "download", "--out", "output"]
+    args = console.parse_cli_args(raw_args)
+    assert args.verbose

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,14 @@
+"""Alien Wallpaper Command Line Interface tests."""
+
+import pytest
+
+from alien_wallpaper import console
+
+
+def test_parse_cli_args_when_called_with_no_args_fails(capsys):
+    """Verifies parse_cli_args stderr output when called with no arguments."""
+    raw_args = []
+    with pytest.raises(SystemExit):
+        console.parse_cli_args(raw_args)
+    output = capsys.readouterr().err
+    assert "the following arguments are required: cmd" in output


### PR DESCRIPTION
* Fix script when called with no arguments to return normal error
* Add `-v` as a short option for `--verbose`
* Add ascii time to log messages
* Log id and error code when failing to download an image

Closes #14, #15 